### PR TITLE
Add httplike tests

### DIFF
--- a/network/benchmarks/netperf/nptest/nptest.go
+++ b/network/benchmarks/netperf/nptest/nptest.go
@@ -441,6 +441,7 @@ func (t *NetPerfRpc) ReceiveOutput(data *WorkerOutput, reply *int) error {
 
 	var outputLog string
 	var bw string
+	var tr string
 	var cpuSender string
 	var cpuReceiver string
 
@@ -469,12 +470,20 @@ func (t *NetPerfRpc) ReceiveOutput(data *WorkerOutput, reply *int) error {
 		bw = parseNetperfBandwidth(data.Output)
 		registerDataPoint(testcase.Label, 0, bw, currentJobIndex)
 		testcases[currentJobIndex].Finished = true
-
+	case netperfHTTPTest:
+		outputLog = outputLog + fmt.Sprintln("Received netperf (http) output from worker", data.Worker, "for test", testcase.Label,
+			"from", testcase.SourcePod, "to", testcase.DestinationPod) + data.Output
+		writeOutputFile(outputCaptureFile, outputLog)
+		tr = parseNetperfTransactionrate(data.Output)
+		registerDataPoint(testcase.Label, 0, tr, currentJobIndex)
+		testcases[currentJobIndex].Finished = true
 	}
 
 	switch data.Type {
 	case iperfTcpTest:
 		fmt.Println("Jobdone from worker", data.Worker, "Bandwidth was", bw, "Mbits/sec. CPU usage sender was", cpuSender, "%. CPU usage receiver was", cpuReceiver, "%.")
+	case netperfHTTPTest:
+		fmt.Println("Jobdone from worker", data.Worker, "Transactionrate was", tr, "Trans/sec")
 	default:
 		fmt.Println("Jobdone from worker", data.Worker, "Bandwidth was", bw, "Mbits/sec")
 	}

--- a/network/benchmarks/netperf/nptest/nptest.go
+++ b/network/benchmarks/netperf/nptest/nptest.go
@@ -58,6 +58,7 @@ var workerStateMap map[string]*workerState
 var iperfTCPOutputRegexp *regexp.Regexp
 var iperfUDPOutputRegexp *regexp.Regexp
 var netperfOutputRegexp *regexp.Regexp
+var netperfhttpOutputRegexp *regexp.Regexp
 var iperfCPUOutputRegexp *regexp.Regexp
 
 var dataPoints map[string][]point
@@ -178,6 +179,7 @@ func init() {
 	iperfTCPOutputRegexp = regexp.MustCompile("SUM.*\\s+(\\d+)\\sMbits/sec\\s+receiver")
 	iperfUDPOutputRegexp = regexp.MustCompile("\\s+(\\S+)\\sMbits/sec\\s+\\S+\\s+ms\\s+")
 	netperfOutputRegexp = regexp.MustCompile("\\s+\\d+\\s+\\d+\\s+\\d+\\s+\\S+\\s+(\\S+)\\s+")
+	netperfhttpOutputRegexp = regexp.MustCompile("(\\S+).Trans\\S+\\s+")
 	iperfCPUOutputRegexp = regexp.MustCompile(`local/sender\s(\d+\.\d+)%\s\((\d+\.\d+)%\w/(\d+\.\d+)%\w\),\sremote/receiver\s(\d+\.\d+)%\s\((\d+\.\d+)%\w/(\d+\.\d+)%\w\)`)
 
 	dataPoints = make(map[string][]point)
@@ -426,6 +428,15 @@ func parseIperfCpuUsage(output string) (string, string) {
 func parseNetperfBandwidth(output string) string {
 	// Parses the output of netperf and grabs the Bbits/sec from the output
 	match := netperfOutputRegexp.FindStringSubmatch(output)
+	if match != nil && len(match) > 1 {
+		return match[1]
+	}
+	return "0"
+}
+
+func parseNetperfTransactionrate(output string) string {
+	// Parses the output of netperf and grabs the Bbits/sec from the output
+	match := netperfhttpOutputRegexp.FindStringSubmatch(output)
 	if match != nil && len(match) > 1 {
 		return match[1]
 	}

--- a/network/benchmarks/netperf/nptest/nptest.go
+++ b/network/benchmarks/netperf/nptest/nptest.go
@@ -170,7 +170,12 @@ func init() {
 		{SourceNode: "netperf-w1", DestinationNode: "netperf-w2", Label: "10 netperf. Same VM using Pod IP", Type: netperfTest, ClusterIP: false},
 		{SourceNode: "netperf-w1", DestinationNode: "netperf-w2", Label: "11 netperf. Same VM using Virtual IP", Type: netperfTest, ClusterIP: true},
 		{SourceNode: "netperf-w1", DestinationNode: "netperf-w3", Label: "12 netperf. Remote VM using Pod IP", Type: netperfTest, ClusterIP: false},
-		{SourceNode: "netperf-w3", DestinationNode: "netperf-w2", Label: "13 netperf. Remote VM using Virtual IP", Type: netperfTest, ClusterIP: true},
+		{SourceNode: "netperf-w3", DestinationNode: "netperf-w2", Label: "13 netperf. Remote VM using Virtual IP", Type: netperfHTTPTest, ClusterIP: true},
+		{SourceNode: "netperf-w1", DestinationNode: "netperf-w2", Label: "14 netperf HTTP. Same VM using Pod IP", Type: netperfHTTPTest, ClusterIP: false},
+		{SourceNode: "netperf-w1", DestinationNode: "netperf-w2", Label: "15 netperf HTTP. Same VM using Virtual IP", Type: netperfHTTPTest, ClusterIP: true},
+		{SourceNode: "netperf-w1", DestinationNode: "netperf-w3", Label: "16 netperf HTTP. Remote VM using Pod IP", Type: netperfHTTPTest, ClusterIP: false, MSS: mssMin},
+		{SourceNode: "netperf-w3", DestinationNode: "netperf-w2", Label: "17 netperf HTTP. Remote VM using Virtual IP", Type: netperfHTTPTest, ClusterIP: true},
+		{SourceNode: "netperf-w2", DestinationNode: "netperf-w2", Label: "18 netperf HTTP. Hairpin Pod to own Virtual IP", Type: netperfHTTPTest, ClusterIP: true},
 	}
 
 	currentJobIndex = 0

--- a/network/benchmarks/netperf/nptest/nptest.go
+++ b/network/benchmarks/netperf/nptest/nptest.go
@@ -637,6 +637,20 @@ func netperfClient(serverHost, serverPort string, workItemType int) (rv string) 
 	return
 }
 
+// Invoke and run a netperf http client and return the output if successful.
+func netperfHTTPClient(serverHost, serverPort string, workItemType int) (rv string) {
+	output, success := cmdExec(netperfPath, []string{netperfPath, "-H", serverHost, "-l", "20", "-P", "1", "-t",  "TCP_CRR", "--", "-r", "32,1024", "-o", "THROUGHPUT,THROUGHPUT_UNITS"}, 15)
+	if success {
+		fmt.Println(output)
+		rv = output
+	} else {
+		fmt.Println("Error running netperf client", output)
+	}
+
+	return
+}
+
+
 func cmdExec(command string, args []string, timeout int32) (rv string, rc bool) {
 	cmd := exec.Cmd{Path: command, Args: args}
 

--- a/network/benchmarks/netperf/nptest/nptest.go
+++ b/network/benchmarks/netperf/nptest/nptest.go
@@ -85,6 +85,7 @@ const (
 	iperfTcpTest = iota
 	iperfUdpTest = iota
 	netperfTest  = iota
+	netperfHTTPTest = iota
 )
 
 // NetPerfRpc service that exposes RegisterClient and ReceiveOutput for clients
@@ -292,7 +293,7 @@ func allocateWorkToClient(workerS *workerState, reply *WorkItem) {
 			}
 			return
 
-		case v.Type == netperfTest:
+		case v.Type == netperfTest || v.Type == netperfHTTPTest:
 			reply.ClientItem.Port = "12865"
 			return
 		}
@@ -532,6 +533,10 @@ func handleClientWorkItem(client *rpc.Client, workItem *WorkItem) {
 		client.Call("NetPerfRpc.ReceiveOutput", WorkerOutput{Output: outputString, Worker: worker, Type: workItem.ClientItem.Type}, &reply)
 	case workItem.ClientItem.Type == netperfTest:
 		outputString := netperfClient(workItem.ClientItem.Host, workItem.ClientItem.Port, workItem.ClientItem.Type)
+		var reply int
+		client.Call("NetPerfRpc.ReceiveOutput", WorkerOutput{Output: outputString, Worker: worker, Type: workItem.ClientItem.Type}, &reply)
+	case workItem.ClientItem.Type == netperfHTTPTest:
+		outputString := netperfHTTPClient(workItem.ClientItem.Host, workItem.ClientItem.Port, workItem.ClientItem.Type)
 		var reply int
 		client.Call("NetPerfRpc.ReceiveOutput", WorkerOutput{Output: outputString, Worker: worker, Type: workItem.ClientItem.Type}, &reply)
 	}


### PR DESCRIPTION
Extend the test cases with transaction/sec measurements.
Uses netperf test type TCP_CRR.